### PR TITLE
fix 🐛 theme revert and status bar behavior with ignoreSystemMode off

### DIFF
--- a/features/appSettings/components/Entries/FontFamily.tsx
+++ b/features/appSettings/components/Entries/FontFamily.tsx
@@ -3,6 +3,7 @@ import { Modal, TouchableOpacity, Text, Dimensions, View, StyleSheet, TouchableW
 import { Ionicons } from '@expo/vector-icons';
 import { Colors } from 'react-native-ui-lib';
 import { AppSettingsEntryBase, type AppSettingsEntryBaseProps } from './Base';
+import { ScrollView } from 'react-native-gesture-handler';
 
 export interface AppSettingsModalFontFamilyProps<TSettings extends Record<string, any>>
     extends Omit<AppSettingsEntryBaseProps, 'children'> {
@@ -72,7 +73,7 @@ export function AppSettingsModalFontFamily<TSettings extends Record<string, any>
                 </TouchableWithoutFeedback>
                 <View style={[styles.modalWrapper, { top: modalPosition.top, left: modalPosition.left }]}>
                     <View style={styles.caret} />
-                    <View style={styles.modalContent}>
+                    <ScrollView style={styles.modalContent}>
                         <Text style={styles.modalTitle}>Select an Option</Text>
                         {options.map((option, index) => (
                             <TouchableOpacity key={index} onPress={() => handleOptionSelect(option)} style={styles.option}>
@@ -80,7 +81,7 @@ export function AppSettingsModalFontFamily<TSettings extends Record<string, any>
                                 {option === value && <Ionicons name="checkmark" size={24} class='text-lame-300' />}
                             </TouchableOpacity>
                         ))}
-                    </View>
+                    </ScrollView>
                 </View>
             </Modal>
         </AppSettingsEntryBase>
@@ -99,7 +100,7 @@ const styles = StyleSheet.create({
     },
     modalContent: {
         backgroundColor: Colors.$backgroundDefault,
-        padding: 20,
+        paddingHorizontal: 20,
         borderRadius: 10,
         shadowColor: '#000',
         shadowOffset: { width: 0, height: 2 },
@@ -107,6 +108,7 @@ const styles = StyleSheet.create({
         shadowRadius: 2,
         elevation: 5,
         width: 250,
+        height: 300,
     },
     caret: {
         position: 'absolute',
@@ -125,6 +127,7 @@ const styles = StyleSheet.create({
         fontSize: 20,
         fontWeight: 'bold',
         marginBottom: 20,
+        marginTop: 30,
     },
     option: {
         display: 'flex',

--- a/features/theme/index.tsx
+++ b/features/theme/index.tsx
@@ -36,6 +36,16 @@ export interface CreateThemeOptions {
     componentDefaults?: Record<ModifiableComponent, Record<string, any>>;
 }
 
+// Utility function to handle color scheme setting logic
+function setColorScheme(scheme: 'light' | 'dark', ignoreSystemMode: boolean) {
+    if (ignoreSystemMode) {
+        Colors.setScheme(scheme as SchemeType);
+    } else {
+        const systemScheme = Appearance.getColorScheme() as 'light' | 'dark' | null;
+        Colors.setScheme(systemScheme || 'default');
+    }
+}
+
 export function createTheme({
     ignoreSystemMode,
     supportDarkMode,
@@ -85,13 +95,7 @@ export function createTheme({
         return (scheme: 'light' | 'dark') => {
             setTheme((prev) => {
                 const next = { ...prev, scheme };
-
-                if (next.ignoreSystemMode) {
-                    Colors.setScheme(scheme as SchemeType);
-                } else {
-                    Colors.setScheme('default');
-                }
-
+                setColorScheme(scheme, next.ignoreSystemMode);
                 return next;
             });
         };
@@ -102,13 +106,16 @@ export function createTheme({
         const [state, setState] = React.useState<'light' | 'dark'>(scheme);
 
         React.useEffect(() => {
-            const systemScheme = Appearance.getColorScheme() as 'light' | 'dark' | null;
-            const initialScheme = ignoreSystemMode ? scheme : systemScheme ?? scheme;
-            Colors.setScheme(initialScheme as SchemeType);
-            setState(initialScheme);
+            setColorScheme(scheme, ignoreSystemMode);
+            setState(scheme);
         }, [scheme, ignoreSystemMode]);
 
         return state;
+    }
+
+    function useIgnoreSystemMode() {
+        const { ignoreSystemMode } = useAtomValue(atom);
+        return ignoreSystemMode
     }
 
     function ThemeProviderComponent({ children }: { children: React.ReactNode }) {
@@ -121,7 +128,7 @@ export function createTheme({
         );
 
         React.useEffect(() => {
-            Colors.setScheme(scheme as SchemeType);
+            setColorScheme(scheme, ignoreSystemMode);
             setNavThemeState(
                 createReactNavigationTheme(
                     availableSchemes[scheme],
@@ -130,7 +137,9 @@ export function createTheme({
             );
         }, [scheme, ignoreSystemMode]);
 
-        return <ThemeProvider value={navThemeState}>{children}</ThemeProvider>;
+        return (
+                <ThemeProvider value={navThemeState}>{children}</ThemeProvider>
+        );
     }
 
     function ThemeSettings() {
@@ -141,13 +150,7 @@ export function createTheme({
         const dispatch = () => {
             setState((prev) => {
                 const next = { ...prev, ignoreSystemMode: !ignoreSystemMode };
-
-                if (next.ignoreSystemMode) {
-                    Colors.setScheme(prev.scheme || defaultScheme);
-                } else {
-                    Colors.setScheme('default');
-                }
-
+                setColorScheme(prev.scheme || defaultScheme, next.ignoreSystemMode);
                 return next;
             });
         };
@@ -178,6 +181,7 @@ export function createTheme({
     return {
         useChangeTheme: useChangeScheme,
         useThemeScheme,
+        useIgnoreSystemMode,
         ThemeProvider: ThemeProviderComponent,
         ThemeSettings,
     };

--- a/features/theme/index.tsx
+++ b/features/theme/index.tsx
@@ -36,7 +36,6 @@ export interface CreateThemeOptions {
     componentDefaults?: Record<ModifiableComponent, Record<string, any>>;
 }
 
-// Utility function to handle color scheme setting logic
 function setColorScheme(scheme: 'light' | 'dark', ignoreSystemMode: boolean) {
     if (ignoreSystemMode) {
         Colors.setScheme(scheme as SchemeType);


### PR DESCRIPTION
### Status
Ready

### Description

- Fixed theme issue where it now reverts to the system default when ignoreSystemMode is turned off.
- Make the statubar unchanged when ignoreSystemMode is turned off 