### PR TITLE
fix: 🐛 add optional chaining to observer entity access (#19)

### DIFF
--- a/utils/observer/index.ts
+++ b/utils/observer/index.ts
@@ -109,7 +109,7 @@ export class EntityObserver<
             this.observers[entity][event].forEach((x) => x(data, event));
         }
 
-        if (this.observers[entity].all) {
+        if (this.observers[entity]?.all) {
             this.observers[entity].all.forEach((x) => x(data, event));
         }
     }


### PR DESCRIPTION
Updated the observer logic to use optional chaining when accessing the 'all' observers for an entity, preventing potential runtime errors when the entity does not exist.